### PR TITLE
Validate purchase products using sheet data

### DIFF
--- a/app/api/purchase/route.ts
+++ b/app/api/purchase/route.ts
@@ -1,34 +1,61 @@
 import { NextResponse } from "next/server"
-import { getBalance, updateBalance, addTransaction } from "@/lib/sheets"
+import {
+  getBalance,
+  updateBalance,
+  addTransaction,
+  getProducts,
+} from "@/lib/sheets"
 
 export async function POST(request: Request) {
   try {
-    const { phone, products, totalPrice } = await request.json()
+    const { phone, products } = await request.json()
+
+    const productDefs = await getProducts()
+    const productMap = new Map(productDefs.map((p) => [p.product_id, p]))
+
+    let total = 0
+    for (const { productId, qty } of products) {
+      const def = productMap.get(productId)
+      if (!def) {
+        return NextResponse.json(
+          { error: `Unknown product: ${productId}` },
+          { status: 400 },
+        )
+      }
+      if (!def.active) {
+        return NextResponse.json(
+          { error: `Inactive product: ${productId}` },
+          { status: 400 },
+        )
+      }
+      total += def.price * qty
+    }
 
     // Check balance
     const currentBalance = await getBalance(phone)
-    if (currentBalance < totalPrice) {
+    if (currentBalance < total) {
       return NextResponse.json({ error: "Insufficient balance" }, { status: 400 })
     }
 
     // Update balance
-    const newBalance = currentBalance - totalPrice
+    const newBalance = currentBalance - total
     await updateBalance(phone, newBalance)
 
     // Add transaction records
-    for (const product of products) {
+    for (const { productId, qty } of products) {
+      const def = productMap.get(productId)!
       await addTransaction({
         type: "purchase",
         phone,
-        product_id: product.id,
-        qty: product.quantity,
-        price: product.price,
-        total: product.price * product.quantity,
-        note: `Purchase: ${product.name}`,
+        product_id: productId,
+        qty,
+        price: def.price,
+        total: def.price * qty,
+        note: `Purchase: ${def.name}`,
       })
     }
 
-    return NextResponse.json({ success: true, newBalance })
+    return NextResponse.json({ success: true, newBalance, total })
   } catch (error) {
     console.error("Error processing purchase:", error)
     return NextResponse.json({ error: "Failed to process purchase" }, { status: 500 })

--- a/lib/sheets.ts
+++ b/lib/sheets.ts
@@ -6,6 +6,7 @@ interface Product {
   product_id: number
   name: string
   price: number
+  active: boolean
 }
 
 interface Balance {
@@ -83,20 +84,39 @@ export async function getProducts(): Promise<Product[]> {
     product_id: Number.parseInt(row[0]),
     name: row[1],
     price: Number.parseInt(row[2]),
+    active: row[3] !== "FALSE",
   }))
 }
 
-export async function addProduct(name: string, price: number): Promise<void> {
+export async function addProduct(
+  name: string,
+  price: number,
+  active = true,
+): Promise<void> {
   const products = await getProducts()
-  const newId = products.length > 0 ? Math.max(...products.map((p) => p.product_id)) + 1 : 1
-  await writeSheet("Products", [[newId, name, price]])
+  const newId =
+    products.length > 0
+      ? Math.max(...products.map((p) => p.product_id)) + 1
+      : 1
+  await writeSheet("Products", [[newId, name, price, active ? "TRUE" : "FALSE"]])
 }
 
-export async function updateProduct(productId: number, name: string, price: number): Promise<void> {
+export async function updateProduct(
+  productId: number,
+  name: string,
+  price: number,
+  active = true,
+): Promise<void> {
   const rows = await readSheet("Products")
-  const rowIndex = rows.findIndex((row, index) => index > 0 && Number.parseInt(row[0]) === productId)
+  const rowIndex = rows.findIndex(
+    (row, index) => index > 0 && Number.parseInt(row[0]) === productId,
+  )
   if (rowIndex !== -1) {
-    await updateSheet("Products", `A${rowIndex + 1}:C${rowIndex + 1}`, [[productId, name, price]])
+    await updateSheet(
+      "Products",
+      `A${rowIndex + 1}:D${rowIndex + 1}`,
+      [[productId, name, price, active ? "TRUE" : "FALSE"]],
+    )
   }
 }
 


### PR DESCRIPTION
## Summary
- verify submitted purchase products exist and are active
- compute purchase totals from sheet prices and use for balance and transactions
- expose product activity in sheet helpers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ad36b77a24832ba37cafabcf927851